### PR TITLE
Fallbacks for FeedName

### DIFF
--- a/gravityforms-power-boost.php
+++ b/gravityforms-power-boost.php
@@ -240,9 +240,18 @@ class Gravity_Forms_Power_Boost
 			{
 				foreach( $feeds as $feed )
 				{
+					$feedName = "";
+					if (isset($feed['meta']['feed_name']))
+					{
+						$feedName = $feed['meta']['feed_name'];
+					} elseif (isset($feed['meta']['feedName'])) {
+						$feedName = $feed['meta']['feedName'];
+					} else {
+						$feedName = "Unnamed: ".$feed['addon_slug'];
+					}
 					?>
 					<input type="checkbox" class="gform_feeds" value="<?php echo esc_attr( $feed['id'] ); ?>" id="feed_<?php echo esc_attr( $feed['id'] ); ?>" />
-					<label for="feed_<?php echo esc_attr( $feed['id'] ); ?>"><?php echo esc_html( $feed['meta']['feed_name'] ); ?></label>
+					<label for="feed_<?php echo esc_attr( $feed['id'] ); ?>"><?php echo esc_html( $feedName ); ?></label>
 					<br /><br />
 					<?php
 				}


### PR DESCRIPTION
I noticed that some feeds use feedName instead of feed_name, and some feeds don't have a feed name defined. I added a fallback for this, so that every feed should display something.