### PR TITLE
small fixes in load process

### DIFF
--- a/includes/class-gfpb-local-json-addon.php
+++ b/includes/class-gfpb-local-json-addon.php
@@ -208,7 +208,7 @@ class GFPB_Local_JSON_Addon extends GFAddOn {
 			return;
 		}
 
-		$form_id = rgpost( 'form_id' );
+		$form_id = (int) rgpost( 'form_id' );
 
 		// does the form exist?
 		if ( false === GFAPI::get_form( $form_id ) ) {
@@ -223,6 +223,9 @@ class GFPB_Local_JSON_Addon extends GFAddOn {
 			return;
 		}
 		$forms_array = json_decode( $json, true );
+		if (isset($forms_array['version'])) {
+		    unset($forms_array['version']);
+		}
 		foreach ( $forms_array as $form ) {
 			if ( empty( $form['id'] ) || $form['id'] !== $form_id ) {
 				continue;

--- a/includes/class-gfpb-local-json-addon.php
+++ b/includes/class-gfpb-local-json-addon.php
@@ -223,9 +223,6 @@ class GFPB_Local_JSON_Addon extends GFAddOn {
 			return;
 		}
 		$forms_array = json_decode( $json, true );
-		if (isset($forms_array['version'])) {
-		    unset($forms_array['version']);
-		}
 		foreach ( $forms_array as $form ) {
 			if ( empty( $form['id'] ) || $form['id'] !== $form_id ) {
 				continue;


### PR DESCRIPTION
Hey guys,
I found one problem with the "Load" process and pushing PR.

`$form_id` is returned as string, instead of int. because of this load process is failing (in my exported JSON the form id is int as well)

Also added unset for the passed JSON, so we don't do unneeded iteration of `version` index.