### PR TITLE
Allow plugins or theme to manipulate feed delete on import

### DIFF
--- a/includes/class-gfpb-form-replacer.php
+++ b/includes/class-gfpb-form-replacer.php
@@ -290,6 +290,13 @@ class GFPB_Form_Replacer {
 		// Update the forms.
 		$updated_count  = 0;
 		$imported_forms = array();
+
+		// These addons, we know handle feeds themselves
+		$addons_that_export_feeds = array( 'gravityflow', 'gravityformsadvancedpostcreation' );
+
+		// Allow theme or plugins to manipulate this array
+		$addons_that_export_feeds = apply_filters('gfpb_local_json_addons_that_export_feeds', $addons_that_export_feeds);
+
 		foreach ( $forms_array as $form ) {
 			if ( empty( $form['id'] ) ) {
 				continue;
@@ -307,13 +314,7 @@ class GFPB_Form_Replacer {
 			foreach ( $feeds as $feed ) {
 				$should_delete = false;
 
-				// Is this a GravityFlow feed?
-				// Or an Advanced Post Creation feed?
-				$addons_that_export_feeds = array( 'gravityflow', 'gravityformsadvancedpostcreation' );
-
-				// Allow theme or plugins to manipulate this array
-				$addons_that_export_feeds = apply_filters('gfpb_local_json_addons_that_export_feeds', $addons_that_export_feeds);
-
+				// Is this feed already handled by another addon?
 				if ( isset( $feed['addon_slug'] ) && in_array( $feed['addon_slug'], $addons_that_export_feeds, true ) ) {
 					$should_delete = true;
 				}

--- a/includes/class-gfpb-form-replacer.php
+++ b/includes/class-gfpb-form-replacer.php
@@ -302,14 +302,25 @@ class GFPB_Form_Replacer {
 				continue;
 			}
 
-			// Delete all GravityFlow feeds or they will be duplicated.
+			// Delete specific feeds or they will be duplicated.
 			$feeds = GFAPI::get_feeds( null, $form['id'] );
 			foreach ( $feeds as $feed ) {
+				$should_delete = false;
+
 				// Is this a GravityFlow feed?
 				// Or an Advanced Post Creation feed?
 				$addons_that_export_feeds = array( 'gravityflow', 'gravityformsadvancedpostcreation' );
+
+				// Allow theme or plugins to manipulate this array
+				$addons_that_export_feeds = apply_filters('gfpb_local_json_addons_that_export_feeds', $addons_that_export_feeds);
+
 				if ( isset( $feed['addon_slug'] ) && in_array( $feed['addon_slug'], $addons_that_export_feeds, true ) ) {
-					// Yes.
+					$should_delete = true;
+				}
+				
+				// Allow theme or plugins to prevent deletion of the feed
+				$should_delete = apply_filters( 'gfpb_local_json_should_delete_feed', $should_delete, $feed );
+				if ( $should_delete ) {
 					$result = GFAPI::delete_feed( $feed['id'] );
 				}
 			}

--- a/includes/class-gfpb-form-replacer.php
+++ b/includes/class-gfpb-form-replacer.php
@@ -319,7 +319,7 @@ class GFPB_Form_Replacer {
 				}
 				
 				// Allow theme or plugins to prevent deletion of the feed
-				$should_delete = apply_filters( 'gfpb_local_json_should_delete_feed', $should_delete, $feed );
+				$should_delete = apply_filters( 'gfpb_local_json_should_delete_feed', $should_delete, $feed, $form );
 				if ( $should_delete ) {
 					$result = GFAPI::delete_feed( $feed['id'] );
 				}

--- a/includes/class-gfpb-local-json-addon.php
+++ b/includes/class-gfpb-local-json-addon.php
@@ -227,14 +227,25 @@ class GFPB_Local_JSON_Addon extends GFAddOn {
 				continue;
 			}
 
-			// Delete all GravityFlow feeds or they will be duplicated.
+			// Delete specific feeds or they will be duplicated.
 			$feeds = GFAPI::get_feeds( null, $form['id'] );
 			foreach ( $feeds as $feed ) {
+				$should_delete = false;
+
 				// Is this a GravityFlow feed?
 				// Or an Advanced Post Creation feed?
 				$addons_that_export_feeds = array( 'gravityflow', 'gravityformsadvancedpostcreation' );
+
+				// Allow theme or plugins to manipulate this array
+				$addons_that_export_feeds = apply_filters('gfpb_local_json_addons_that_export_feeds', $addons_that_export_feeds);
+				
 				if ( isset( $feed['addon_slug'] ) && in_array( $feed['addon_slug'], $addons_that_export_feeds, true ) ) {
-					// Yes.
+					$should_delete = true;
+				}
+				
+				// Allow theme or plugins to prevent deletion of the feed
+				$should_delete = apply_filters( 'gfpb_local_json_should_delete_feed', $should_delete, $feed );
+				if ( $should_delete ) {
 					$result = GFAPI::delete_feed( $feed['id'] );
 				}
 			}

--- a/includes/class-gfpb-local-json-addon.php
+++ b/includes/class-gfpb-local-json-addon.php
@@ -244,7 +244,7 @@ class GFPB_Local_JSON_Addon extends GFAddOn {
 				}
 				
 				// Allow theme or plugins to prevent deletion of the feed
-				$should_delete = apply_filters( 'gfpb_local_json_should_delete_feed', $should_delete, $feed );
+				$should_delete = apply_filters( 'gfpb_local_json_should_delete_feed', $should_delete, $feed, $form );
 				if ( $should_delete ) {
 					$result = GFAPI::delete_feed( $feed['id'] );
 				}

--- a/includes/class-gfpb-local-json-addon.php
+++ b/includes/class-gfpb-local-json-addon.php
@@ -222,6 +222,13 @@ class GFPB_Local_JSON_Addon extends GFAddOn {
 		}
 		$forms_array    = json_decode( $json, true );
 		$imported_forms = array();
+
+		// These addons, we know handle feeds themselves
+		$addons_that_export_feeds = array( 'gravityflow', 'gravityformsadvancedpostcreation' );
+
+		// Allow theme or plugins to manipulate this array
+		$addons_that_export_feeds = apply_filters('gfpb_local_json_addons_that_export_feeds', $addons_that_export_feeds);
+
 		foreach ( $forms_array as $form ) {
 			if ( empty( $form['id'] ) || $form['id'] !== $form_id ) {
 				continue;
@@ -231,14 +238,8 @@ class GFPB_Local_JSON_Addon extends GFAddOn {
 			$feeds = GFAPI::get_feeds( null, $form['id'] );
 			foreach ( $feeds as $feed ) {
 				$should_delete = false;
-
-				// Is this a GravityFlow feed?
-				// Or an Advanced Post Creation feed?
-				$addons_that_export_feeds = array( 'gravityflow', 'gravityformsadvancedpostcreation' );
-
-				// Allow theme or plugins to manipulate this array
-				$addons_that_export_feeds = apply_filters('gfpb_local_json_addons_that_export_feeds', $addons_that_export_feeds);
 				
+				// Is this feed already handled by another addon?
 				if ( isset( $feed['addon_slug'] ) && in_array( $feed['addon_slug'], $addons_that_export_feeds, true ) ) {
 					$should_delete = true;
 				}


### PR DESCRIPTION
Adds the ability for themes & plugins to specify if a feed should be deleted on import via a filter.
Adds the ability for themes & plugins to manipulate the array of addons that export feeds to prevent deletion.